### PR TITLE
[RAILS] HTML render javascript_tag sd <script>

### DIFF
--- a/Rails/HTML (Rails).sublime-syntax
+++ b/Rails/HTML (Rails).sublime-syntax
@@ -12,12 +12,26 @@ contexts:
     - match: ''
       push: 'scope:text.html.basic'
       with_prototype:
+
+        - match: "<%= javascript_tag do"
+          scope: punctuation.section.embedded.ruby
+          push:
+            - match: <%\s*end\s*%>
+              scope: shit.buster
+              pop: true
+            - match: \%\>\s*
+              scope: asdadasdas.asdf.sdafs.df.sdaf.sdf
+              embed: scope:source.js
+              embed_scope: source.js.embedded.html
+              escape: <%\s*end\s*%>
+
         - match: "<%+#"
           scope: punctuation.definition.comment.erb
           push:
             - meta_scope: comment.block.erb
             - match: "%>"
               pop: true
+
         - match: "<%+(?!>)[-=]?"
           scope: punctuation.section.embedded.ruby
           push:


### PR DESCRIPTION
I would like Rails `javascript_tag` to embed javascript. This is not the recommended way by rails, though it is possible and in some small apps, it's ok.
 
This patch is not working but I think I am close.  And it looks like this. 
![screenshot 2017-11-20 11 01 35](https://user-images.githubusercontent.com/3492040/33012834-5f77cba0-cde2-11e7-8878-487bac5e9221.png)

I would like a hint, I don't understand whats not working?
